### PR TITLE
Correct T18 entry

### DIFF
--- a/build-fw.py
+++ b/build-fw.py
@@ -153,8 +153,8 @@ elif board_name == "tx16s":
     firmware_options = options_radiomaster_tx16s
     maxsize = 2 * 1024 * 1024
 elif board_name == "t18":
-    cmake_options["PCB"] = "X10"
-    cmake_options["PCBREV"] = "T18"
+    extra_options["PCB"] = "X10"
+    extra_options["PCBREV"] = "T18"
     firmware_options = options_jumper_t18
     maxsize = 2 * 1024 * 1024
 else:


### PR DESCRIPTION
@vitas 
When I try to compile for T18 it errors with saying that cmake_options are not defined. I think the reason is obvious and corrected in this PR. I could not test, but it looks reasonable to me.

btw, many THX for your docker, it saved my life :)